### PR TITLE
support ignoring realtime on internal calls

### DIFF
--- a/src/Listeners/AddDiscussionViewHandler.php
+++ b/src/Listeners/AddDiscussionViewHandler.php
@@ -33,7 +33,10 @@ class AddDiscussionViewHandler
      * @var SettingsRepositoryInterface
      */
     public $settings;
-    private ExtensionManager $extensions;
+    /**
+     ** @var ExtensionManager
+     */
+    private $extensions;
 
     public function __construct(Dispatcher $bus, SettingsRepositoryInterface $settings, ExtensionManager $extensions)
     {

--- a/src/Listeners/AddDiscussionViewHandler.php
+++ b/src/Listeners/AddDiscussionViewHandler.php
@@ -13,6 +13,7 @@ namespace Flarumite\DiscussionViews\Listeners;
 
 use Carbon\Carbon;
 use Flarum\Api\Controller\ShowDiscussionController;
+use Flarum\Extension\ExtensionManager;
 use Flarum\Http\RequestUtil;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarumite\DiscussionViews\Events\DiscussionWasViewed;
@@ -32,15 +33,20 @@ class AddDiscussionViewHandler
      * @var SettingsRepositoryInterface
      */
     public $settings;
+    private ExtensionManager $extensions;
 
-    public function __construct(Dispatcher $bus, SettingsRepositoryInterface $settings)
+    public function __construct(Dispatcher $bus, SettingsRepositoryInterface $settings, ExtensionManager $extensions)
     {
         $this->bus = $bus;
         $this->settings = $settings;
+        $this->extensions = $extensions;
     }
 
     public function __invoke(ShowDiscussionController $controller, &$data, ServerRequestInterface $request)
     {
+        // Ignore tracking for realtime, to stop bumping views.
+        if (isset($request->getQueryParams()['realtime']) && $this->extensions->isEnabled('blomstra-realtime')) return;
+
         /**
          * @var \Flarum\User\User
          */


### PR DESCRIPTION
Realtime builds it payload by using the internal Flarum api to hit controllers directly. This extension is able to understand crawlers but will track hits by realtime when building its payload. This PR allows the extension to ignore realtime in building metrics.